### PR TITLE
chore: publish packages

### DIFF
--- a/packages/ai_edge/CHANGELOG.md
+++ b/packages/ai_edge/CHANGELOG.md
@@ -1,3 +1,33 @@
+## 0.2.0
+
+### Breaking Changes
+
+* **API Simplification**: Replaced config objects with individual named parameters (#11)
+  - `createModel()` now accepts individual parameters instead of `ModelConfig` object
+  - `createSession()` now accepts individual parameters instead of `SessionConfig` object  
+  - `initialize()` now accepts individual parameters for both model and session configuration
+  - Config classes (`ModelConfig` and `SessionConfig`) are still available internally but not exposed in public API
+
+### Improvements
+
+* **Developer Experience**:
+  - More intuitive API with direct parameter passing
+  - Better IDE autocomplete support without config object nesting
+  - Optional parameters with sensible defaults:
+    - `maxTokens`: Default 1024 (previously required)
+    - `temperature`: Default 0.8
+    - `randomSeed`: Default 1
+    - `topK`: Default 40
+
+* **Platform Implementation**:
+  - Made non-critical parameters optional in Android native implementation
+  - Fixed platform channel communication issues with Unit type handling
+
+* **Code Quality**:
+  - Removed unnecessary `toString()` override from `GenerationEvent` class
+  - Updated documentation to remove references to deprecated exception types
+  - Updated tests to reflect the new API design
+
 ## 0.1.0
 
 ### Breaking Changes

--- a/packages/ai_edge/pubspec.yaml
+++ b/packages/ai_edge/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ai_edge
 description: "Flutter plugin for on-device AI inference powered by MediaPipe GenAI. Run large language models directly on iOS and Android with optimized performance."
-version: 0.1.0
+version: 0.2.0
 homepage: https://github.com/KyoheiG3/ai_edge
 repository: https://github.com/KyoheiG3/ai_edge
 documentation: https://github.com/KyoheiG3/ai_edge


### PR DESCRIPTION
## Overview
Prepare ai_edge package v0.2.0 for publishing to pub.dev

## Changes
- Bump ai_edge version from 0.1.0 to 0.2.0
- Update CHANGELOG.md with breaking changes and improvements
- Document API simplification from config objects to individual parameters

## Breaking Changes
- `createModel()` now accepts individual parameters instead of `ModelConfig` object
- `createSession()` now accepts individual parameters instead of `SessionConfig` object
- `initialize()` now accepts individual parameters for configuration

## References
- #11: API simplification refactor