### PR TITLE
chore: prepare ai_edge_fc 0.0.1 release

### DIFF
--- a/packages/ai_edge_fc/CHANGELOG.md
+++ b/packages/ai_edge_fc/CHANGELOG.md
@@ -1,3 +1,40 @@
 ## 0.0.1
 
-* TODO: Describe initial release.
+Initial release of the AI Edge Function Calling plugin for on-device AI with function calling capabilities.
+
+### Features
+
+* **Function Calling Support**: Comprehensive function calling implementation for Google MediaPipe GenAI
+  - Tool and function declaration support
+  - Function execution with structured responses
+  - Support for multiple function calls in a single request
+  
+* **Model Formatters**: Support for multiple model formatting strategies
+  - GemmaFormatter for Gemma models
+  - HammerFormatter for Hammer models
+  - LlamaFormatter for Llama models
+  
+* **Structured Data**: Protocol Buffer-based data structures
+  - Type-safe message passing between Dart and native code
+  - Support for complex nested data structures
+  - Automatic serialization/deserialization
+  
+* **Streaming Support**: Real-time streaming responses for function calls
+  - Incremental response processing
+  - Function call detection during streaming
+  
+* **Example Functions**: Built-in example function implementations
+  - Weather information retrieval
+  - Calculator operations
+  - Current time function
+
+### Platform Support
+
+* Android support with MediaPipe GenAI integration
+* iOS support pending (platform limitations)
+
+### Developer Experience
+
+* Complete example application demonstrating all features
+* Comprehensive test coverage for all models
+* Clean API design with intuitive usage patterns

--- a/packages/ai_edge_fc/pubspec.yaml
+++ b/packages/ai_edge_fc/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   ai_edge: ^0.2.0
   protobuf: ^4.2.0
   collection: ^1.19.1
+  fixnum: ^1.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Overview
Prepare the `ai_edge_fc` package for its initial 0.0.1 release to pub.dev.

## Changes
- Updated CHANGELOG.md with comprehensive release notes for version 0.0.1
- Added `fixnum` (^1.1.1) as a required dependency for Protocol Buffer support

## Test Instructions
1. Run `flutter pub get` in the ai_edge_fc package directory
2. Verify all dependencies resolve correctly
3. Run package tests: `flutter test`
4. Review CHANGELOG.md for completeness

## References
- Related to the function calling feature implementation
- Package will be published to https://pub.dev/packages/ai_edge_fc