### PR TITLE
chore: prepare ai_edge_model_dl v0.1.0 release

### DIFF
--- a/packages/ai_edge_model_dl/CHANGELOG.md
+++ b/packages/ai_edge_model_dl/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 0.1.0
+
+### Features
+
+- Initial release of ai_edge_model_dl package for efficient model downloading and management
+- Resumable downloads with automatic retry on interruption
+- Real-time progress tracking with speed and time estimates
+- Checksum validation (MD5/SHA256) for model integrity
+- Parallel chunk downloading for optimized performance
+- Platform-specific storage management with customizable paths
+- Custom exception handling with specific error codes (checksumMismatch, fileSizeMismatch, invalidChecksumFormat)
+- Comprehensive model management APIs (list, check existence, delete)
+- Seamless integration with AI Edge packages for simplified model path resolution
+
+### Documentation
+
+- Complete README with usage examples and API reference

--- a/packages/ai_edge_model_dl/pubspec.yaml
+++ b/packages/ai_edge_model_dl/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ai_edge_model_dl
-description: "A new Flutter package project."
-version: 0.0.1
+description: "Efficient model downloader for AI Edge with resumable downloads, progress tracking, and validation."
+version: 0.1.0
 homepage: https://github.com/KyoheiG3/ai_edge
 repository: https://github.com/KyoheiG3/ai_edge
 documentation: https://github.com/KyoheiG3/ai_edge


### PR DESCRIPTION
## Overview
Prepare the ai_edge_model_dl package for its initial v0.1.0 release on pub.dev.

## Changes
- Added CHANGELOG.md with initial release notes documenting all features
- Updated package description in pubspec.yaml to be more descriptive and professional
- Bumped version from 0.0.1 to 0.1.0 for initial release

## Test Instructions
1. Verify CHANGELOG.md is properly formatted
2. Confirm pubspec.yaml has correct version and description
3. Run `flutter pub publish --dry-run` in the package directory to validate

## References
- Part of the AI Edge suite of packages for on-device AI inference