### PR TITLE
chore: update ai_edge_model_dl version in example lock files

### DIFF
--- a/examples/ai_chat/pubspec.lock
+++ b/examples/ai_chat/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       path: "../../packages/ai_edge_model_dl"
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.1.0"
   async:
     dependency: transitive
     description:

--- a/examples/ai_chat_fc/pubspec.lock
+++ b/examples/ai_chat_fc/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       path: "../../packages/ai_edge_model_dl"
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.1.0"
   async:
     dependency: transitive
     description:


### PR DESCRIPTION
## Overview
Update the pubspec.lock files in the example apps to reflect the new version of ai_edge_model_dl package (0.1.0).

## Changes
- Updated `examples/ai_chat/pubspec.lock` to use ai_edge_model_dl v0.1.0
- Updated `examples/ai_chat_fc/pubspec.lock` to use ai_edge_model_dl v0.1.0

## Test Instructions
1. Run `flutter pub get` in both example directories
2. Verify the apps build and run correctly with the updated package version

## References
- Related to #16 (ai_edge_model_dl v0.1.0 release)