### PR TITLE
docs: add iOS memory entitlements configuration for large models

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,19 @@ await aiEdge.initialize(
 
 ## 📱 Platform Configuration
 
+### iOS
+
+The plugin automatically includes necessary MediaPipe frameworks. For large models, you may need to increase memory limit by adding the following entitlement to `ios/Runner/Runner.entitlements`:
+
+```xml
+<dict>
+  <key>com.apple.developer.kernel.increased-memory-limit</key>
+  <true/>
+</dict>
+```
+
+Make sure to configure `CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;` in your Xcode project settings.
+
 ### Android
 
 Update `android/app/build.gradle`:
@@ -281,10 +294,6 @@ For large models, add to `AndroidManifest.xml`:
     android:largeHeap="true"
     ...>
 ```
-
-### iOS
-
-The plugin automatically includes necessary MediaPipe frameworks. No additional configuration needed.
 
 ## 📝 License
 

--- a/examples/ai_chat/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/ai_chat/ios/Runner.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		8B5A94542EC46BBD00F6B048 /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		8E1D2215AB3C71A25F329349 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		9464EC7C39E282E235310C62 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
@@ -139,6 +140,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				8B5A94542EC46BBD00F6B048 /* Runner.entitlements */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -161,7 +163,6 @@
 				8E1D2215AB3C71A25F329349 /* Pods-RunnerTests.release.xcconfig */,
 				6571174D35D1FEF50AC4152B /* Pods-RunnerTests.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -353,9 +354,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -470,6 +475,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = MX36A76L68;
 				ENABLE_BITCODE = NO;
@@ -653,6 +659,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = MX36A76L68;
 				ENABLE_BITCODE = NO;
@@ -676,6 +683,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = MX36A76L68;
 				ENABLE_BITCODE = NO;

--- a/examples/ai_chat/ios/Runner/Runner.entitlements
+++ b/examples/ai_chat/ios/Runner/Runner.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.kernel.increased-memory-limit</key>
+	<true/>
+</dict>
+</plist>

--- a/packages/ai_edge/README.md
+++ b/packages/ai_edge/README.md
@@ -145,6 +145,21 @@ await aiEdge.initialize(
   </dict>
   ```
 
+- **Recommended Devices**:
+
+  - Optimal performance on iPhone 12 or newer
+  - iPad with A14 Bionic chip or later
+  - Other high-end iOS devices with comparable specs
+
+- For large models, you may need to increase memory limit by adding the following entitlement to `ios/Runner/Runner.entitlements`:
+  ```xml
+  <dict>
+    <key>com.apple.developer.kernel.increased-memory-limit</key>
+    <true/>
+  </dict>
+  ```
+  Make sure to configure `CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;` in your Xcode project settings.
+
 ### Android Requirements
 
 - **Minimum SDK**: Android API level 24 (Android 7.0) or later


### PR DESCRIPTION
## Overview

This PR adds documentation and configuration for iOS memory entitlements to support large AI models. When running large language models on iOS devices, apps may encounter memory limitations. The increased memory limit entitlement allows apps to use more memory, which is essential for loading and running large AI models.

## Changes

- Added `Runner.entitlements` file with `com.apple.developer.kernel.increased-memory-limit` entitlement to the example app
- Updated Xcode project configuration to reference the entitlements file (`CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements`)
- Enhanced root README.md with iOS platform configuration section including:
  - Instructions for adding memory entitlements
  - Configuration steps for Xcode project settings
- Improved packages/ai_edge/README.md with:
  - Recommended iOS device specifications (iPhone 12 or newer, iPad with A14 Bionic or later)
  - Detailed entitlements setup instructions
  - Xcode project configuration guidance

## Test Instructions

1. Open the example app in Xcode: `examples/ai_chat/ios/Runner.xcodeproj`
2. Verify that the entitlements file is properly referenced in the project settings
3. Check that `CODE_SIGN_ENTITLEMENTS` is set to `Runner/Runner.entitlements` in build settings
4. Build and run the app with a large AI model to confirm memory allocation works correctly
5. Review the documentation changes in both README files for clarity and accuracy

## References

- Apple Developer Documentation: [Entitlements](https://developer.apple.com/documentation/bundleresources/entitlements)
- Related to supporting large AI models on iOS platform